### PR TITLE
Buffer Read 

### DIFF
--- a/src/artp3.cpp
+++ b/src/artp3.cpp
@@ -682,7 +682,7 @@ int *R_sel_id, int *R_marg_id){
   	}
   	gin.close();
     */
-    read_in_buffer(gene_out[g].c_str(), ncp, nperm+1, stat);
+    read_in_buffer(gene_out[g].c_str(), ncp, nperm+1, stat, nthread);
     if(remove(gene_out[g].c_str())){
       error("Cannot delete gene output file");
     }
@@ -935,7 +935,7 @@ int *R_sel_id, int *R_marg_id){
   		}
   	}
   	gin.close();*/
-    read_in_buffer(gene_out[g].c_str(), ncp, nperm+1, stat);
+    read_in_buffer(gene_out[g].c_str(), ncp, nperm+1, stat, nthread);
 
     if(remove(gene_out[g].c_str())){
       error("Cannot delete gene output file");

--- a/src/artp3.cpp
+++ b/src/artp3.cpp
@@ -1,20 +1,20 @@
 #include "util.h"
-
+#include "buffer.h"
 
 struct STAT{
-  
+
   float stat;
   int id;
-  
+
   bool operator < (const STAT& st) const{ // ascending
     return (stat < st.stat);
   }
-  
+
   STAT(float st, int i){
     stat = st;
     id = i;
   }
-  
+
 };
 
 bool descending(const STAT &a, const STAT &b){ return a.stat > b.stat; }
@@ -23,19 +23,19 @@ bool ascending(const STAT &a, const STAT &b){ return a.stat < b.stat; }
 STAT STAT0(.0f, -1);
 
 struct MINP{
-  
+
   int stat;
   int id;
-  
+
   bool operator < (const MINP &mp) const{
     return (stat < mp.stat);
   }
-  
+
   MINP(int st, int i){
     stat = st;
     id = i;
   }
-  
+
 };
 
 MINP MINP0(0, -1);
@@ -52,7 +52,7 @@ typedef vector<string> svec;
 typedef vector<vector<string> > smat;
 
 void load_U(double *R_vU, fmat &U, int nsnp){
-  
+
   U = fmat (nsnp, fvec (nsnp, .0f));
   int k = -1;
   for(int i = 0; i < nsnp; ++i){
@@ -61,20 +61,20 @@ void load_U(double *R_vU, fmat &U, int nsnp){
       U[i][j] = R_vU[k];
     }
   }
-  
+
 }
 
 void load_score0(double *R_score0, fvec &score0, int nsnp){
-  
+
   score0 = fvec (nsnp, .0f);
   for(int i = 0; i < nsnp; ++i){
     score0[i] = R_score0[i];
   }
-  
+
 }
 
 void load_cov(double *R_vV, fmat &V, int nsnp){
-  
+
   V = fmat (nsnp, fvec (nsnp, .0f));
   int k = -1;
   for(int i = 0; i < nsnp; ++i){
@@ -83,11 +83,11 @@ void load_cov(double *R_vV, fmat &V, int nsnp){
       V[i][j] = R_vV[k];
     }
   }
-  
+
 }
 
 void load_sigma2(const fmat &V, fvec &sigma2){
-  
+
   int nsnp = V.size();
   sigma2 = fvec (nsnp, .0f);
   for(int i = 0; i < nsnp; ++i){
@@ -95,9 +95,9 @@ void load_sigma2(const fmat &V, fvec &sigma2){
   }
 }
 
-void load_gene_idx(int *R_vgene_idx, int *R_gene_start, int *R_gene_end, 
+void load_gene_idx(int *R_vgene_idx, int *R_gene_start, int *R_gene_end,
 imat &gene_idx, int ngene){
-  
+
   gene_idx = imat (ngene);
   for(int i = 0; i < ngene; ++i){
   	ivec idx;
@@ -106,12 +106,12 @@ imat &gene_idx, int ngene){
   	}
   	gene_idx[i] = idx;
   }
-  
+
 }
 
-void load_gene_cutpoint(int *R_vgene_cutpoint, int *R_gene_cutpoint_start, int *R_gene_cutpoint_end, 
+void load_gene_cutpoint(int *R_vgene_cutpoint, int *R_gene_cutpoint_start, int *R_gene_cutpoint_end,
 imat &cutpoint, int ngene){
-  
+
   cutpoint = imat (ngene);
   for(int i = 0; i < ngene; ++i){
   	ivec cp;
@@ -120,29 +120,29 @@ imat &cutpoint, int ngene){
   	}
     cutpoint[i] = cp;
   }
-  
+
 }
 
 
 //gene_idx is for a single gene (otherwise it should be imat rather than ivec)
-void extract_score(fvec &S, const fvec &score0, 
+void extract_score(fvec &S, const fvec &score0,
 const ivec &gene_idx){
-  
+
 	int ns = gene_idx.size();//number of SNPs in a gene
-		
+
 	S = fvec(ns);
 	for(int j = 0; j < ns; ++j){
 		int J = gene_idx[j];
 		S[j] = score0[J];
 	}
-	
+
 }
 
-void extract_cov(fmat &Sigma, const fmat &V, 
+void extract_cov(fmat &Sigma, const fmat &V,
 const ivec &gene_idx){
-	
+
 	int ns = gene_idx.size();//number of SNPs in a gene
-		
+
 	Sigma = fmat(ns, fvec(ns));
 	for(int j = 0; j < ns; ++j){
 		int J = gene_idx[j];
@@ -152,14 +152,14 @@ const ivec &gene_idx){
 			Sigma[k][j] = Sigma[j][k];
 		}
 	}
-	
+
 }
 
 
 void search1(fvec &stat, ivec &sel_id, int &marg_id, const fvec &S, const fmat &Sigma, const int &mc){
-  
+
   int ns = S.size();
-  
+
 	//find best marginal SNP
 	int id = -1;
 	double max_stat = -1.0;
@@ -170,30 +170,30 @@ void search1(fvec &stat, ivec &sel_id, int &marg_id, const fvec &S, const fmat &
 			id = j;
 		}
 	}
-	
+
   stat = fvec(1, max_stat);
-	
+
 	assert(id >= 0 && id < ns);
 	sel_id = ivec(1, id);
   marg_id = id;
-  
+
 	if(ns == 1){
 		return;
 	}
-	
+
 	dmat inv_Sigma22(mc + 1, dvec(mc + 1, .0));
 	inv_Sigma22[0][0] = 1.0 / Sigma[id][id];
-	
+
 	dvec S2(mc + 1, .0);
 	S2[0] = S[id];
-	
+
 	vector<bool> used(ns, false);
 	used[id] = true;
-	
+
 	double w = max_stat;
-	
+
 	for(int j = 1; j <= mc; ++j){//j is the number of SNPs being selected
-		
+
 		dvec v(j, .0); // v = (Sigma22)^-1 S2
 		for(int i = 0; i < j; ++i){
 			v[i] = .0;
@@ -201,7 +201,7 @@ void search1(fvec &stat, ivec &sel_id, int &marg_id, const fvec &S, const fmat &
 				v[i] += inv_Sigma22[i][k] * S2[k];
 			}
 		}
-		
+
 		max_stat = -1.0;
 		double max_qf2 = -1.0;
 		id = -1;
@@ -209,7 +209,7 @@ void search1(fvec &stat, ivec &sel_id, int &marg_id, const fvec &S, const fmat &
 			if(used[k]){
 				continue;
 			}
-			
+
 			double S1 = S[k];
 			double qf1 = .0; //qf1 = sigma12 (Sigma22)^-1 S2
 			double qf2 = .0; //qf2 = sigma12 (Sigma22)^-1 sigma21
@@ -221,20 +221,20 @@ void search1(fvec &stat, ivec &sel_id, int &marg_id, const fvec &S, const fmat &
 				}
 				qf2 += tmp * Sigma[sel_id[l]][k];
 			}
-			
-			
+
+
 			double stat = w + (S1 * S1 - 2.0 * S1 * qf1 + qf1 * qf1)/(Sigma[k][k] - qf2);
 			if(stat > max_stat){
 				max_stat = stat;
 				id = k;
 				max_qf2 = qf2;
 			}
-			
+
 		}
-		
+
 		w = max_stat;
 		stat.push_back(max_stat);
-    
+
 		sel_id.push_back(id);
 		used[id] = true;
 		S2[j] = S[id];
@@ -248,21 +248,21 @@ void search1(fvec &stat, ivec &sel_id, int &marg_id, const fvec &S, const fmat &
 			inv_Sigma22[j][l] *= -inv_Sigma22[j][j];
 			inv_Sigma22[l][j] = inv_Sigma22[j][l];
 		}
-		
+
 		for(int l = 0; l < j; ++l){
 			for(int t = 0; t < j; ++t){
 				inv_Sigma22[l][t] +=  inv_Sigma22[l][j] * inv_Sigma22[t][j] / inv_Sigma22[j][j];
 			}
 		}
-		
+
 	}
-	
+
 }
 
 void search2(fvec &stat, ivec &sel_id, int &marg_id, const fvec &S, const fmat &Sigma, const int &mc){
-  
+
   int ns = S.size();
-  
+
 	//find best marginal SNP
 	int id = -1;
 	double max_stat = -1.0;
@@ -273,16 +273,16 @@ void search2(fvec &stat, ivec &sel_id, int &marg_id, const fvec &S, const fmat &
 			id = j;
 		}
 	}
-	
+
   stat = fvec(1, max_stat);
   assert(id >= 0 && id < ns);
   sel_id = ivec(1, id);
   marg_id = id;
-  
+
 	if(ns == 1){
 		return;
 	}
-  
+
   //find best pair
   int id1 = -1;
   int id2 = -1;
@@ -300,17 +300,17 @@ void search2(fvec &stat, ivec &sel_id, int &marg_id, const fvec &S, const fmat &
       }
     }
   }
-  
+
   stat.push_back(max_stat);
   assert(id1 >= 0 && id1 < ns);
   assert(id2 >= 0 && id2 < ns);
   sel_id = ivec(1, id1);
   sel_id.push_back(id2);
-  
+
   if(ns == 2){
     return;
   }
-	
+
 	dmat inv_Sigma22(mc + 1, dvec(mc + 1, .0));
   double a = Sigma[id1][id1];
   double b = Sigma[id1][id2];
@@ -320,19 +320,19 @@ void search2(fvec &stat, ivec &sel_id, int &marg_id, const fvec &S, const fmat &
   inv_Sigma22[0][1] = -b / e;
   inv_Sigma22[1][0] = inv_Sigma22[0][1];
   inv_Sigma22[1][1] = a / e;
-	
+
 	dvec S2(mc + 1, .0);
 	S2[0] = S[id1];
   S2[1] = S[id2];
-	
+
 	vector<bool> used(ns, false);
 	used[id1] = true;
   used[id2] = true;
-	
+
 	double w = max_stat;
-	
+
 	for(int j = 2; j <= mc; ++j){//j is the number of SNPs being selected
-		
+
 		dvec v(j, .0); // v = (Sigma22)^-1 S2
 		for(int i = 0; i < j; ++i){
 			v[i] = .0;
@@ -340,7 +340,7 @@ void search2(fvec &stat, ivec &sel_id, int &marg_id, const fvec &S, const fmat &
 				v[i] += inv_Sigma22[i][k] * S2[k];
 			}
 		}
-		
+
 		max_stat = -1.0;
 		double max_qf2 = -1.0;
 		id = -1;
@@ -348,7 +348,7 @@ void search2(fvec &stat, ivec &sel_id, int &marg_id, const fvec &S, const fmat &
 			if(used[k]){
 				continue;
 			}
-			
+
 			double S1 = S[k];
 			double qf1 = .0; //qf1 = sigma12 (Sigma22)^-1 S2
 			double qf2 = .0; //qf2 = sigma12 (Sigma22)^-1 sigma21
@@ -360,20 +360,20 @@ void search2(fvec &stat, ivec &sel_id, int &marg_id, const fvec &S, const fmat &
 				}
 				qf2 += tmp * Sigma[sel_id[l]][k];
 			}
-			
-			
+
+
 			double stat = w + (S1 * S1 - 2.0 * S1 * qf1 + qf1 * qf1)/(Sigma[k][k] - qf2);
 			if(stat > max_stat){
 				max_stat = stat;
 				id = k;
 				max_qf2 = qf2;
 			}
-			
+
 		}
-		
+
 		w = max_stat;
 		stat.push_back(max_stat);
-    
+
 		sel_id.push_back(id);
 		used[id] = true;
 		S2[j] = S[id];
@@ -387,29 +387,29 @@ void search2(fvec &stat, ivec &sel_id, int &marg_id, const fvec &S, const fmat &
 			inv_Sigma22[j][l] *= -inv_Sigma22[j][j];
 			inv_Sigma22[l][j] = inv_Sigma22[j][l];
 		}
-		
+
 		for(int l = 0; l < j; ++l){
 			for(int t = 0; t < j; ++t){
 				inv_Sigma22[l][t] +=  inv_Sigma22[l][j] * inv_Sigma22[t][j] / inv_Sigma22[j][j];
 			}
 		}
-		
+
 	}
-	
+
 }
 
 #if __PARALLEL__
 void rnorm(drand48_data &buf, int n, fvec &v){
-	
+
 	v = fvec (n);
-	
+
 	int m = -1;
 	if(n % 2){
 		m = n/2 + 1;
 	}else{
 		m = n/2;
 	}
-	
+
   int k = -1;
 	for(int i = 0; i < m; ++i){
 		float u1, u2, s;
@@ -421,7 +421,7 @@ void rnorm(drand48_data &buf, int n, fvec &v){
 			u2 = 2.0f * (float) r2 - 1.0f;
 			s = u1 * u1 + u2 * u2;
 		}while(s >= 1.0f || (s < 1e-12 && s > -1e-12));
-		
+
 		s = (float) sqrt((-2.0 * log(s)) / s);
     ++k;
 		v[k] = u1 * s;
@@ -430,20 +430,20 @@ void rnorm(drand48_data &buf, int n, fvec &v){
       v[k] = u2 * s;
     }
 	}
-	
+
 }
 #else
 void rnorm(int n, fvec &v){
-  
+
 	v = fvec (n);
-	
+
 	int m = -1;
 	if(n % 2){
 		m = n/2 + 1;
 	}else{
 		m = n/2;
 	}
-	
+
   int k = -1;
 	for(int i = 0; i < m; ++i){
 		float u1, u2, s;
@@ -455,7 +455,7 @@ void rnorm(int n, fvec &v){
 			u2 = 2.0f * (float) r2 - 1.0f;
 			s = u1 * u1 + u2 * u2;
 		}while(s >= 1.0f || (s < 1e-12 && s > -1e-12));
-		
+
 		s = (float) sqrt((-2.0 * log(s)) / s);
     ++k;
 		v[k] = u1 * s;
@@ -464,35 +464,35 @@ void rnorm(int n, fvec &v){
       v[k] = u2 * s;
     }
 	}
-	
+
 }
 #endif
 
 void load_group_id(int *R_group_id, ivec &group_id, int ngene){
-  
+
   group_id = ivec(ngene);
   for(int i = 0; i < ngene; ++i){
     group_id[i] = R_group_id[i] - 1;
   }
-  
+
 }
-  
+
 void load_gene_id(int *R_gene_id, ivec &gene_id, int ngene){
-  
+
   gene_id = ivec(ngene);
   for(int i = 0; i < ngene; ++i){
     gene_id[i] = R_gene_id[i] - 1;
   }
-  
+
 }
 
 void load_pathway_cutpoint(int *R_pathway_cutpoint, ivec &pathway_cutpoint, int ncp){
-  
+
   pathway_cutpoint = ivec(ncp);
   for(int i = 0; i < ncp; ++i){
     pathway_cutpoint[i] = R_pathway_cutpoint[i] - 1;
   }
-  
+
 }
 
 
@@ -500,32 +500,32 @@ void load_pathway_cutpoint(int *R_pathway_cutpoint, ivec &pathway_cutpoint, int 
 extern "C" {
 
 void artp3_chr(char **R_file_prefix, int *R_method,
-int *R_nperm, int *R_seed, 
-int *R_nthread, int *R_nsnp, int *R_ngene, 
-double *R_vU, double *R_score0, double *R_vV, 
-int *R_vgene_idx, int *R_gene_start, int *R_gene_end, 
-int *R_vgene_cutpoint, 
-int *R_gene_cutpoint_start, int *R_gene_cutpoint_end, 
-double *R_gene_pval, int *R_arr_rank, 
+int *R_nperm, int *R_seed,
+int *R_nthread, int *R_nsnp, int *R_ngene,
+double *R_vU, double *R_score0, double *R_vV,
+int *R_vgene_idx, int *R_gene_start, int *R_gene_end,
+int *R_vgene_cutpoint,
+int *R_gene_cutpoint_start, int *R_gene_cutpoint_end,
+double *R_gene_pval, int *R_arr_rank,
 int *R_sel_id, int *R_marg_id){
-  
+
   int len_file_prefix = strlen(*R_file_prefix);
   char *file_prefix = new char[len_file_prefix + 1];
   file_prefix[0] = '\0';
   strcat(file_prefix, *R_file_prefix);
-  
+
   int method = *R_method;
   assert(method == 3);
   if(method == 3){
     ;
   }
-  
+
   int nperm = *R_nperm;
   int seed = *R_seed;
   int nthread = *R_nthread;
   int nsnp = *R_nsnp;
   int ngene = *R_ngene;
-  
+
   fvec score0;
   fvec sigma2;
   fmat U;
@@ -534,16 +534,16 @@ int *R_sel_id, int *R_marg_id){
   load_cov(R_vV, V, nsnp);
   load_sigma2(V, sigma2);
   load_U(R_vU, U, nsnp);
-  
+
   imat gene_idx; // index of SNPs in a gene
-  
-  load_gene_idx(R_vgene_idx, R_gene_start, R_gene_end, 
+
+  load_gene_idx(R_vgene_idx, R_gene_start, R_gene_end,
   gene_idx, ngene);
-  
+
   imat cutpoint;
-  load_gene_cutpoint(R_vgene_cutpoint, R_gene_cutpoint_start, R_gene_cutpoint_end, 
+  load_gene_cutpoint(R_vgene_cutpoint, R_gene_cutpoint_start, R_gene_cutpoint_end,
   cutpoint, ngene);
-  
+
   string fprefix (file_prefix);
   svec gene_out (ngene, fprefix);
   for(int g = 0; g < ngene; ++g){
@@ -551,7 +551,7 @@ int *R_sel_id, int *R_marg_id){
     gid << g;
     gene_out[g] = gene_out[g] + string("GID.") + gid.str() + string(".bin");
   }
-  
+
   // write obs statistics for all genes
   imat sel_id(ngene);
   ivec marg_id(ngene);
@@ -571,25 +571,25 @@ int *R_sel_id, int *R_marg_id){
       vs[j].stat = -s[j];
       vs[j].id = j;
   	}
-    
+
     sort(vs.begin(), vs.end(), descending);
     marg_id[g] = vs[0].id;
     for(int j = 0; j < ns; ++j){
       sel_id[g].push_back(vs[j].id);
     }
-    
+
     sort(s.begin(), s.end());
     for(int j = 1; j <= max_cutpoint; ++j){
       s[j] += s[j - 1];
     }
-    
+
     for(int k = 0; k < ncp; ++k){
       float u = -s[cutpoint[g][k]];
       gout.write((char*)(&u), sizeof(u));
     }
   	gout.close();
   }
-  
+
   int i_sel_id = -1;
   for(int g = 0; g < ngene; ++g){
     R_marg_id[g] = gene_idx[g][marg_id[g]] + 1;
@@ -604,10 +604,10 @@ int *R_sel_id, int *R_marg_id){
       --nn;
     }
   }
-  
+
   int ngap = min(10000, nperm);
   int nblock = nperm / ngap;
-  
+
   for(int b = 0; b < nblock; ++b){
   	fmat null(ngap, fvec (nsnp, .0f));
   	drand48_data buf;
@@ -629,7 +629,7 @@ int *R_sel_id, int *R_marg_id){
 	  		}
 	  	}
 	  }
-	  
+
 	  // write null statistics to local files (per gene)
 	  #pragma omp parallel num_threads(min(nthread, ngene))
 	  {
@@ -648,12 +648,12 @@ int *R_sel_id, int *R_marg_id){
 	  			for(int j = 0; j < ns; ++j){
 	  				s[j] = null[i][gene_idx[g][j]];
 	  			}
-          
+
           sort(s.begin(), s.end());
           for(int j = 1; j <= max_cutpoint; ++j){
             s[j] += s[j - 1];
           }
-          
+
           for(int k = 0; k < ncp; ++k){
             float u = -s[cutpoint[g][k]];
             gout.write((char*)(&u), sizeof(u));
@@ -664,14 +664,14 @@ int *R_sel_id, int *R_marg_id){
 	  }
 	  //fmat().swap(null);
   }
-  
+
   // read null statistics (per gene)
   int irk = -1;
   for(int g = 0; g < ngene; ++g){
   	int ncp = cutpoint[g].size();
   	vector<VecStat> stat(ncp, VecStat (nperm + 1, STAT0));
-    fstream gin(gene_out[g].c_str(), ios::in | ios::binary);
-    
+    /*fstream gin(gene_out[g].c_str(), ios::in | ios::binary);
+
   	for(int i = 0; i < nperm + 1; ++i){
   		for(int j = 0; j < ncp; ++j){
   			float s = .0f;
@@ -681,11 +681,12 @@ int *R_sel_id, int *R_marg_id){
   		}
   	}
   	gin.close();
-    
+    */
+    read_in_buffer(gene_out[g].c_str(), ncp, nperm+1, stat);
     if(remove(gene_out[g].c_str())){
       error("Cannot delete gene output file");
     }
-  	
+
   	imat arr_rank(ncp, ivec (nperm + 1, 0));
   	#pragma omp parallel num_threads(min(ncp, nthread))
   	{
@@ -698,9 +699,9 @@ int *R_sel_id, int *R_marg_id){
   			}
   		}
   	}
-  	
+
   	vector<VecStat>().swap(stat);
-    
+
     ivec gene_min_p (nperm + 1, -1);
     ivec subsum(nthread, 0);
     ivec subtie(nthread, 0);
@@ -713,7 +714,7 @@ int *R_sel_id, int *R_marg_id){
       }
     }
     gene_min_p[0] = m;
-    
+
     #pragma omp parallel num_threads(nthread)
     {
       #pragma omp for
@@ -735,7 +736,7 @@ int *R_sel_id, int *R_marg_id){
         }
       }
     }
-    
+
     R_gene_pval[g] = 1.0;
     int rep = 0;
     for(int t = 0; t < nthread; ++t){
@@ -744,7 +745,7 @@ int *R_sel_id, int *R_marg_id){
     }
     R_gene_pval[g] += rep / 2.0;
     R_gene_pval[g] /= nperm + 1;
-    
+
     fstream gout(gene_out[g].c_str(), ios::out | ios::binary);
     if(!gout){
       error("Fail to write gene statistics to file");
@@ -753,54 +754,54 @@ int *R_sel_id, int *R_marg_id){
       gout.write((char*)(&(gene_min_p[i])), sizeof(gene_min_p[i]));
     }
     gout.close();
-    
+
   }
-  
-  
+
+
   delete[] file_prefix;
-  
+
 }
 
 void adajoint_chr(char **R_file_prefix, int *R_method,
-int *R_nperm, int *R_seed, 
-int *R_nthread, int *R_nsnp, int *R_ngene, 
-double *R_vU, double *R_score0, double *R_vV, 
-int *R_vgene_idx, int *R_gene_start, int *R_gene_end, 
-int *R_vgene_cutpoint, 
-int *R_gene_cutpoint_start, int *R_gene_cutpoint_end, 
-double *R_gene_pval, int *R_arr_rank, 
+int *R_nperm, int *R_seed,
+int *R_nthread, int *R_nsnp, int *R_ngene,
+double *R_vU, double *R_score0, double *R_vV,
+int *R_vgene_idx, int *R_gene_start, int *R_gene_end,
+int *R_vgene_cutpoint,
+int *R_gene_cutpoint_start, int *R_gene_cutpoint_end,
+double *R_gene_pval, int *R_arr_rank,
 int *R_sel_id, int *R_marg_id){
-  
+
   int len_file_prefix = strlen(*R_file_prefix);
   char *file_prefix = new char[len_file_prefix + 1];
   file_prefix[0] = '\0';
   strcat(file_prefix, *R_file_prefix);
-  
+
   int method = *R_method;
   assert(method == 1 || method == 2);
-  
+
   int nperm = *R_nperm;
   int seed = *R_seed;
   int nthread = *R_nthread;
   int nsnp = *R_nsnp;
   int ngene = *R_ngene;
-  
+
   fvec score0;
   fmat V;
   fmat U;
   load_score0(R_score0, score0, nsnp);
   load_cov(R_vV, V, nsnp);
   load_U(R_vU, U, nsnp);
-  
+
   imat gene_idx; // index of SNPs in a gene
-  
-  load_gene_idx(R_vgene_idx, R_gene_start, R_gene_end, 
+
+  load_gene_idx(R_vgene_idx, R_gene_start, R_gene_end,
   gene_idx, ngene);
-  
+
   imat cutpoint;
-  load_gene_cutpoint(R_vgene_cutpoint, R_gene_cutpoint_start, R_gene_cutpoint_end, 
+  load_gene_cutpoint(R_vgene_cutpoint, R_gene_cutpoint_start, R_gene_cutpoint_end,
   cutpoint, ngene);
-  
+
   string fprefix (file_prefix);
   svec gene_out (ngene, fprefix);
   for(int g = 0; g < ngene; ++g){
@@ -808,7 +809,7 @@ int *R_sel_id, int *R_marg_id){
     gid << g;
     gene_out[g] = gene_out[g] + string("GID.") + gid.str() + string(".bin");
   }
-  
+
   // write obs statistics for all genes
   imat sel_id(ngene);
   ivec marg_id(ngene);
@@ -817,7 +818,7 @@ int *R_sel_id, int *R_marg_id){
   	if(!gout){
   		error("Fail to write observed statistics to file");
   	}
-  	
+
   	fvec S;
   	fmat Sigma;
   	extract_score(S, score0, gene_idx[g]);
@@ -825,20 +826,20 @@ int *R_sel_id, int *R_marg_id){
   	fvec s;
     int ncp = cutpoint[g].size();
     int mc = cutpoint[g][ncp - 1];
-    
+
     if(method == 1){
       search1(s, sel_id[g], marg_id[g], S, Sigma, mc);
     }else{//assert(method == 2)
       search2(s, sel_id[g], marg_id[g], S, Sigma, mc);
     }
-    
+
     for(int k = 0; k < ncp; ++k){
       float u = s[cutpoint[g][k]];
       gout.write((char*)(&u), sizeof(u));
     }
   	gout.close();
   }
-  
+
   int i_sel_id = -1;
   for(int g = 0; g < ngene; ++g){
     R_marg_id[g] = gene_idx[g][marg_id[g]] + 1;
@@ -853,10 +854,10 @@ int *R_sel_id, int *R_marg_id){
       --nn;
     }
   }
-  
+
   int ngap = min(10000, nperm);
   int nblock = nperm / ngap;
-  
+
   for(int b = 0; b < nblock; ++b){
   	fmat null(ngap, fvec (nsnp, .0f));
   	drand48_data buf;
@@ -876,7 +877,7 @@ int *R_sel_id, int *R_marg_id){
 	  		}
 	  	}
 	  }
-	  
+
 	  // write null statistics to local files (per gene)
 	  #pragma omp parallel num_threads(min(nthread, ngene))
 	  {
@@ -887,17 +888,17 @@ int *R_sel_id, int *R_marg_id){
 	  		if(!gout){
 	  			error("Fail to write null statistics to file");
 	  		}
-	  		
+
 	  		fmat Sigma;
 	  		extract_cov(Sigma, V, gene_idx[g]);
-	  		
+
         int ns = gene_idx[g].size();
         int ncp = cutpoint[g].size();
         int mc = cutpoint[g][ncp - 1];
 	  		for(int i = 0; i < ngap; ++i){
 	  			fvec S;
 	  			extract_score(S, null[i], gene_idx[g]);
-	  			
+
 	  			fvec s;
           ivec sel_id;
           int marg_id;
@@ -906,7 +907,7 @@ int *R_sel_id, int *R_marg_id){
           }else{
             search2(s, sel_id, marg_id, S, Sigma, mc);
           }
-          
+
           for(int k = 0; k < ncp; ++k){
             float u = s[cutpoint[g][k]];
             gout.write((char*)(&u), sizeof(u));
@@ -917,14 +918,14 @@ int *R_sel_id, int *R_marg_id){
 	  }
 	  //fmat().swap(null);
   }
-  
+
   // read null statistics (per gene)
   int irk = -1;
   for(int g = 0; g < ngene; ++g){
   	int ncp = cutpoint[g].size();
   	vector<VecStat> stat(ncp, VecStat (nperm + 1, STAT0));
     fstream gin(gene_out[g].c_str(), ios::in | ios::binary);
-    
+
   	for(int i = 0; i < nperm + 1; ++i){
   		for(int j = 0; j < ncp; ++j){
   			float s = .0f;
@@ -934,11 +935,11 @@ int *R_sel_id, int *R_marg_id){
   		}
   	}
   	gin.close();
-    
+
     if(remove(gene_out[g].c_str())){
       error("Cannot delete gene output file");
     }
-  	
+
   	imat arr_rank(ncp, ivec (nperm + 1, 0));
   	#pragma omp parallel num_threads(min(ncp, nthread))
   	{
@@ -951,9 +952,9 @@ int *R_sel_id, int *R_marg_id){
   			}
   		}
   	}
-  	
+
   	vector<VecStat>().swap(stat);
-    
+
     ivec gene_min_p (nperm + 1, -1);
     ivec subsum(nthread, 0);
     ivec subtie(nthread, 0);
@@ -966,7 +967,7 @@ int *R_sel_id, int *R_marg_id){
       }
     }
     gene_min_p[0] = m;
-    
+
     #pragma omp parallel num_threads(nthread)
     {
       #pragma omp for
@@ -988,7 +989,7 @@ int *R_sel_id, int *R_marg_id){
         }
       }
     }
-    
+
     R_gene_pval[g] = 1.0;
     int rep = 0;
     for(int t = 0; t < nthread; ++t){
@@ -997,7 +998,7 @@ int *R_sel_id, int *R_marg_id){
     }
     R_gene_pval[g] += rep / 2.0;
     R_gene_pval[g] /= nperm + 1;
-    
+
     fstream gout(gene_out[g].c_str(), ios::out | ios::binary);
     if(!gout){
       error("Fail to write gene statistics to file");
@@ -1006,41 +1007,41 @@ int *R_sel_id, int *R_marg_id){
       gout.write((char*)(&(gene_min_p[i])), sizeof(gene_min_p[i]));
     }
     gout.close();
-    
+
   }
-  
-  
+
+
   delete[] file_prefix;
-  
+
 }
 
 
 
-void artp3(char **R_file_prefix, int *R_nperm, int *R_nthread, 
-int *R_ngene, int *R_group_id, int *R_gene_id, 
-int *R_pathway_cutpoint, int *R_ncp, 
+void artp3(char **R_file_prefix, int *R_nperm, int *R_nthread,
+int *R_ngene, int *R_group_id, int *R_gene_id,
+int *R_pathway_cutpoint, int *R_ncp,
 double *R_pathway_pval, int *R_arr_rank, double *R_gene_pval){
-  
+
   int len_file_prefix = strlen(*R_file_prefix);
   char *file_prefix = new char[len_file_prefix + 1];
   file_prefix[0] = '\0';
   strcat(file_prefix, *R_file_prefix);
-  
+
   int nperm = *R_nperm;
   int nthread = *R_nthread;
   int ngene = *R_ngene;
   int ncp = *R_ncp;
-  
+
   ivec group_id;
   load_group_id(R_group_id, group_id, ngene);
-  
+
   ivec gene_id;
   load_gene_id(R_gene_id, gene_id, ngene);
-  
+
   ivec pathway_cutpoint;
   load_pathway_cutpoint(R_pathway_cutpoint, pathway_cutpoint, ncp);
   int max_cutpoint = pathway_cutpoint[ncp - 1];
-  
+
   string fprefix (file_prefix);
   svec gene_out (ngene, fprefix);
   for(int g = 0; g < ngene; ++g){
@@ -1050,7 +1051,7 @@ double *R_pathway_pval, int *R_arr_rank, double *R_gene_pval){
     gid << gene_id[g];
     gene_out[g] = gene_out[g] + string(".CID.") + cid.str() + string(".GID.") + gid.str() + string(".bin");
   }
-  
+
   vector<VecMinp> gene_stat (ngene, VecMinp(nperm + 1, MINP0));
   imat gene_p_stat (ngene, ivec(nperm + 1, -1));
   #pragma omp parallel num_threads(min(nthread, ngene))
@@ -1075,13 +1076,13 @@ double *R_pathway_pval, int *R_arr_rank, double *R_gene_pval){
       VecMinp().swap(gene_stat[g]);
     }
   }
-  
+
   vector<VecMinp>().swap(gene_stat);
-  
+
   for(int g = 0; g < ngene; ++g){
     R_gene_pval[g] = (gene_p_stat[g][0] + 1.0) / (nperm + 1);
   }
-  
+
   vector<VecStat> stat(ncp, VecStat (nperm + 1, STAT0));
   #pragma omp parallel num_threads(nthread)
   {
@@ -1097,7 +1098,7 @@ double *R_pathway_pval, int *R_arr_rank, double *R_gene_pval){
           s[g] += s[g - 1];
         }
       }
-      
+
       for(int k = 0; k < ncp; ++k){
         float u = -s[pathway_cutpoint[k]];
         stat[k][i].stat = u;
@@ -1105,9 +1106,9 @@ double *R_pathway_pval, int *R_arr_rank, double *R_gene_pval){
       }
     }
   }
-  
+
   imat().swap(gene_p_stat);
-  
+
   imat arr_rank(ncp, ivec (nperm + 1, 0));
   #pragma omp parallel num_threads(min(nthread, ncp))
   {
@@ -1122,7 +1123,7 @@ double *R_pathway_pval, int *R_arr_rank, double *R_gene_pval){
     }
   }
   vector<VecStat>().swap(stat);
-  
+
   ivec pathway_min_p(nperm + 1, -1);
   ivec subsum(nthread, 0);
   ivec subtie(nthread, 0);
@@ -1134,7 +1135,7 @@ double *R_pathway_pval, int *R_arr_rank, double *R_gene_pval){
     }
   }
   pathway_min_p[0] = m;
-  
+
   #pragma omp parallel num_threads(nthread)
   {
     #pragma omp for
@@ -1156,7 +1157,7 @@ double *R_pathway_pval, int *R_arr_rank, double *R_gene_pval){
       }
     }
   }
-  
+
   *R_pathway_pval = 1.0;
   int rep = 0;
   for(int t = 0; t < nthread; ++t){
@@ -1165,11 +1166,11 @@ double *R_pathway_pval, int *R_arr_rank, double *R_gene_pval){
   }
   *R_pathway_pval += rep / 2.0;
   *R_pathway_pval /= nperm + 1;
-  
-  
+
+
   delete[] file_prefix;
-  
-  
+
+
 }
 
 }
@@ -1177,34 +1178,34 @@ double *R_pathway_pval, int *R_arr_rank, double *R_gene_pval){
 extern "C" {
 
 void artp3_chr(char **R_file_prefix, int *R_method,
-int *R_nperm, int *R_seed, 
-int *R_nthread, int *R_nsnp, int *R_ngene, 
-double *R_vU, double *R_score0, double *R_vV, 
-int *R_vgene_idx, int *R_gene_start, int *R_gene_end, 
-int *R_vgene_cutpoint, 
-int *R_gene_cutpoint_start, int *R_gene_cutpoint_end, 
-double *R_gene_pval, int *R_arr_rank, 
+int *R_nperm, int *R_seed,
+int *R_nthread, int *R_nsnp, int *R_ngene,
+double *R_vU, double *R_score0, double *R_vV,
+int *R_vgene_idx, int *R_gene_start, int *R_gene_end,
+int *R_vgene_cutpoint,
+int *R_gene_cutpoint_start, int *R_gene_cutpoint_end,
+double *R_gene_pval, int *R_arr_rank,
 int *R_sel_id, int *R_marg_id){
-  
+
   int len_file_prefix = strlen(*R_file_prefix);
   char *file_prefix = new char[len_file_prefix + 1];
   file_prefix[0] = '\0';
   strcat(file_prefix, *R_file_prefix);
-  
+
   int method = *R_method;
   assert(method == 3);
   if(method == 3){
     ;
   }
-  
+
   int nperm = *R_nperm;
   int seed = *R_seed;
   int nthread = *R_nthread;
   int nsnp = *R_nsnp;
   int ngene = *R_ngene;
-  
+
   assert(nthread == 1);
-  
+
   fvec score0;
   fvec sigma2;
   fmat U;
@@ -1213,16 +1214,16 @@ int *R_sel_id, int *R_marg_id){
   load_cov(R_vV, V, nsnp);
   load_sigma2(V, sigma2);
   load_U(R_vU, U, nsnp);
-  
+
   imat gene_idx; // index of SNPs in a gene
-  
-  load_gene_idx(R_vgene_idx, R_gene_start, R_gene_end, 
+
+  load_gene_idx(R_vgene_idx, R_gene_start, R_gene_end,
   gene_idx, ngene);
-  
+
   imat cutpoint;
-  load_gene_cutpoint(R_vgene_cutpoint, R_gene_cutpoint_start, R_gene_cutpoint_end, 
+  load_gene_cutpoint(R_vgene_cutpoint, R_gene_cutpoint_start, R_gene_cutpoint_end,
   cutpoint, ngene);
-  
+
   string fprefix (file_prefix);
   svec gene_out (ngene, fprefix);
   for(int g = 0; g < ngene; ++g){
@@ -1230,7 +1231,7 @@ int *R_sel_id, int *R_marg_id){
     gid << g;
     gene_out[g] = gene_out[g] + string("GID.") + gid.str() + string(".bin");
   }
-  
+
   // write obs statistics for all genes
   imat sel_id(ngene);
   ivec marg_id(ngene);
@@ -1250,25 +1251,25 @@ int *R_sel_id, int *R_marg_id){
       vs[j].stat = -s[j];
       vs[j].id = j;
   	}
-    
+
     sort(vs.begin(), vs.end(), descending);
     marg_id[g] = vs[0].id;
     for(int j = 0; j < ns; ++j){
       sel_id[g].push_back(vs[j].id);
     }
-    
+
     sort(s.begin(), s.end());
     for(int j = 1; j <= max_cutpoint; ++j){
       s[j] += s[j - 1];
     }
-    
+
     for(int k = 0; k < ncp; ++k){
       float u = -s[cutpoint[g][k]];
       gout.write((char*)(&u), sizeof(u));
     }
   	gout.close();
   }
-  
+
   int i_sel_id = -1;
   for(int g = 0; g < ngene; ++g){
     R_marg_id[g] = gene_idx[g][marg_id[g]] + 1;
@@ -1283,10 +1284,10 @@ int *R_sel_id, int *R_marg_id){
       --nn;
     }
   }
-  
+
   int ngap = min(10000, nperm);
   int nblock = nperm / ngap;
-  
+
   srand(seed);
   for(int b = 0; b < nblock; ++b){
   	fmat null(ngap, fvec (nsnp, .0f));
@@ -1303,7 +1304,7 @@ int *R_sel_id, int *R_marg_id){
   			null[i][j] = pchisq(null[i][j], 1, false, true);
   		}
   	}
-	  
+
 	  // write null statistics to local files (per gene)
   	for(int g = 0; g < ngene; ++g){
   		ofstream gout;
@@ -1319,12 +1320,12 @@ int *R_sel_id, int *R_marg_id){
   			for(int j = 0; j < ns; ++j){
   				s[j] = null[i][gene_idx[g][j]];
   			}
-        
+
         sort(s.begin(), s.end());
         for(int j = 1; j <= max_cutpoint; ++j){
           s[j] += s[j - 1];
         }
-        
+
         for(int k = 0; k < ncp; ++k){
           float u = -s[cutpoint[g][k]];
           gout.write((char*)(&u), sizeof(u));
@@ -1334,14 +1335,14 @@ int *R_sel_id, int *R_marg_id){
   	}
 	  //fmat().swap(null);
   }
-  
+
   // read null statistics (per gene)
   int irk = -1;
   for(int g = 0; g < ngene; ++g){
   	int ncp = cutpoint[g].size();
   	vector<VecStat> stat(ncp, VecStat (nperm + 1, STAT0));
     fstream gin(gene_out[g].c_str(), ios::in | ios::binary);
-    
+
   	for(int i = 0; i < nperm + 1; ++i){
   		for(int j = 0; j < ncp; ++j){
   			float s = .0f;
@@ -1351,11 +1352,11 @@ int *R_sel_id, int *R_marg_id){
   		}
   	}
   	gin.close();
-    
+
     if(remove(gene_out[g].c_str())){
       error("Cannot delete gene output file");
     }
-  	
+
   	imat arr_rank(ncp, ivec (nperm + 1, 0));
 		for(int j = 0; j < ncp; ++j){
 			sort(stat[j].begin(), stat[j].end(), descending);
@@ -1364,9 +1365,9 @@ int *R_sel_id, int *R_marg_id){
 				arr_rank[j][id] = i;
 			}
 		}
-  	
+
   	vector<VecStat>().swap(stat);
-    
+
     ivec gene_min_p (nperm + 1, -1);
     ivec subsum(nthread, 0);
     ivec subtie(nthread, 0);
@@ -1379,7 +1380,7 @@ int *R_sel_id, int *R_marg_id){
       }
     }
     gene_min_p[0] = m;
-    
+
     for(int i = 1; i < nperm + 1; ++i){
       int tid = 0;
       int m = nperm + 1;
@@ -1397,7 +1398,7 @@ int *R_sel_id, int *R_marg_id){
         ;
       }
     }
-    
+
     R_gene_pval[g] = 1.0;
     int rep = 0;
     for(int t = 0; t < nthread; ++t){
@@ -1406,7 +1407,7 @@ int *R_sel_id, int *R_marg_id){
     }
     R_gene_pval[g] += rep / 2.0;
     R_gene_pval[g] /= nperm + 1;
-    
+
     fstream gout(gene_out[g].c_str(), ios::out | ios::binary);
     if(!gout){
       error("Fail to write gene statistics to file");
@@ -1415,57 +1416,57 @@ int *R_sel_id, int *R_marg_id){
       gout.write((char*)(&(gene_min_p[i])), sizeof(gene_min_p[i]));
     }
     gout.close();
-    
+
   }
-  
-  
+
+
   delete[] file_prefix;
-  
+
 }
 
 
 void adajoint_chr(char **R_file_prefix, int *R_method,
-int *R_nperm, int *R_seed, 
-int *R_nthread, int *R_nsnp, int *R_ngene, 
-double *R_vU, double *R_score0, double *R_vV, 
-int *R_vgene_idx, int *R_gene_start, int *R_gene_end, 
-int *R_vgene_cutpoint, 
-int *R_gene_cutpoint_start, int *R_gene_cutpoint_end, 
-double *R_gene_pval, int *R_arr_rank, 
+int *R_nperm, int *R_seed,
+int *R_nthread, int *R_nsnp, int *R_ngene,
+double *R_vU, double *R_score0, double *R_vV,
+int *R_vgene_idx, int *R_gene_start, int *R_gene_end,
+int *R_vgene_cutpoint,
+int *R_gene_cutpoint_start, int *R_gene_cutpoint_end,
+double *R_gene_pval, int *R_arr_rank,
 int *R_sel_id, int *R_marg_id){
-  
+
   int len_file_prefix = strlen(*R_file_prefix);
   char *file_prefix = new char[len_file_prefix + 1];
   file_prefix[0] = '\0';
   strcat(file_prefix, *R_file_prefix);
-  
+
   int method = *R_method;
   assert(method == 1 || method == 2);
-  
+
   int nperm = *R_nperm;
   int seed = *R_seed;
   int nthread = *R_nthread;
   int nsnp = *R_nsnp;
   int ngene = *R_ngene;
-  
+
   assert(nthread == 1);
-  
+
   fvec score0;
   fmat V;
   fmat U;
   load_score0(R_score0, score0, nsnp);
   load_cov(R_vV, V, nsnp);
   load_U(R_vU, U, nsnp);
-  
+
   imat gene_idx; // index of SNPs in a gene
-  
-  load_gene_idx(R_vgene_idx, R_gene_start, R_gene_end, 
+
+  load_gene_idx(R_vgene_idx, R_gene_start, R_gene_end,
   gene_idx, ngene);
-  
+
   imat cutpoint;
-  load_gene_cutpoint(R_vgene_cutpoint, R_gene_cutpoint_start, R_gene_cutpoint_end, 
+  load_gene_cutpoint(R_vgene_cutpoint, R_gene_cutpoint_start, R_gene_cutpoint_end,
   cutpoint, ngene);
-  
+
   string fprefix (file_prefix);
   svec gene_out (ngene, fprefix);
   for(int g = 0; g < ngene; ++g){
@@ -1473,7 +1474,7 @@ int *R_sel_id, int *R_marg_id){
     gid << g;
     gene_out[g] = gene_out[g] + string("GID.") + gid.str() + string(".bin");
   }
-  
+
   // write obs statistics for all genes
   imat sel_id(ngene);
   ivec marg_id(ngene);
@@ -1482,7 +1483,7 @@ int *R_sel_id, int *R_marg_id){
     if(!gout){
   		error("Fail to write observed statistics to file");
   	}
-  	
+
   	fvec S;
   	fmat Sigma;
   	extract_score(S, score0, gene_idx[g]);
@@ -1495,14 +1496,14 @@ int *R_sel_id, int *R_marg_id){
     }else{//assert(method == 2)
       search2(s, sel_id[g], marg_id[g], S, Sigma, mc);
     }
-    
+
     for(int k = 0; k < ncp; ++k){
       float u = s[cutpoint[g][k]];
       gout.write((char*)(&u), sizeof(u));
     }
   	gout.close();
   }
-  
+
   int i_sel_id = -1;
   for(int g = 0; g < ngene; ++g){
     R_marg_id[g] = gene_idx[g][marg_id[g]] + 1;
@@ -1517,10 +1518,10 @@ int *R_sel_id, int *R_marg_id){
       --nn;
     }
   }
-  
+
   int ngap = min(10000, nperm);
   int nblock = nperm / ngap;
-  
+
   srand(seed);
   for(int b = 0; b < nblock; ++b){
   	fmat null(ngap, fvec (nsnp, .0f));
@@ -1535,7 +1536,7 @@ int *R_sel_id, int *R_marg_id){
   			}
   		}
   	}
-	  
+
 	  // write null statistics to local files (per gene)
   	for(int g = 0; g < ngene; ++g){
   		ofstream gout;
@@ -1543,7 +1544,7 @@ int *R_sel_id, int *R_marg_id){
   		if(!gout){
   			error("Fail to write null statistics to file");
   		}
-  		
+
   		fmat Sigma;
   		extract_cov(Sigma, V, gene_idx[g]);
       int ncp = cutpoint[g].size();
@@ -1551,7 +1552,7 @@ int *R_sel_id, int *R_marg_id){
   		for(int i = 0; i < ngap; ++i){
   			fvec S;
   			extract_score(S, null[i], gene_idx[g]);
-  			
+
   			fvec s;
         ivec sel_id;
         int marg_id;
@@ -1560,7 +1561,7 @@ int *R_sel_id, int *R_marg_id){
         }else{
           search2(s, sel_id, marg_id, S, Sigma, mc);
         }
-        
+
         for(int k = 0; k < ncp; ++k){
           float u = s[cutpoint[g][k]];
           gout.write((char*)(&u), sizeof(u));
@@ -1570,14 +1571,14 @@ int *R_sel_id, int *R_marg_id){
   	}
 	  //fmat().swap(null);
   }
-  
+
   // read null statistics (per gene)
   int irk = -1;
   for(int g = 0; g < ngene; ++g){
   	int ncp = cutpoint[g].size();
   	vector<VecStat> stat(ncp, VecStat (nperm + 1, STAT0));
     fstream gin(gene_out[g].c_str(), ios::in | ios::binary);
-    
+
   	for(int i = 0; i < nperm + 1; ++i){
   		for(int j = 0; j < ncp; ++j){
   			float s = .0f;
@@ -1587,11 +1588,11 @@ int *R_sel_id, int *R_marg_id){
   		}
   	}
   	gin.close();
-    
+
     if(remove(gene_out[g].c_str())){
       error("Cannot delete gene output file");
     }
-  	
+
   	imat arr_rank(ncp, ivec (nperm + 1, 0));
 		for(int j = 0; j < ncp; ++j){
 			sort(stat[j].begin(), stat[j].end(), descending);
@@ -1600,9 +1601,9 @@ int *R_sel_id, int *R_marg_id){
 				arr_rank[j][id] = i;
 			}
 		}
-  	
+
   	vector<VecStat>().swap(stat);
-    
+
     ivec gene_min_p (nperm + 1, -1);
     ivec subsum(nthread, 0);
     ivec subtie(nthread, 0);
@@ -1615,7 +1616,7 @@ int *R_sel_id, int *R_marg_id){
       }
     }
     gene_min_p[0] = m;
-    
+
     for(int i = 1; i < nperm + 1; ++i){
       int tid = 0;
       int m = nperm + 1;
@@ -1633,7 +1634,7 @@ int *R_sel_id, int *R_marg_id){
         ;
       }
     }
-    
+
     R_gene_pval[g] = 1.0;
     int rep = 0;
     for(int t = 0; t < nthread; ++t){
@@ -1642,7 +1643,7 @@ int *R_sel_id, int *R_marg_id){
     }
     R_gene_pval[g] += rep / 2.0;
     R_gene_pval[g] /= nperm + 1;
-    
+
     fstream gout(gene_out[g].c_str(), ios::out | ios::binary);
     if(!gout){
       error("Fail to write gene statistics to file");
@@ -1651,42 +1652,42 @@ int *R_sel_id, int *R_marg_id){
       gout.write((char*)(&(gene_min_p[i])), sizeof(gene_min_p[i]));
     }
     gout.close();
-    
+
   }
-  
-  
+
+
   delete[] file_prefix;
-  
+
 }
 
 
-void artp3(char **R_file_prefix, int *R_nperm, int *R_nthread, 
-int *R_ngene, int *R_group_id, int *R_gene_id, 
-int *R_pathway_cutpoint, int *R_ncp, 
+void artp3(char **R_file_prefix, int *R_nperm, int *R_nthread,
+int *R_ngene, int *R_group_id, int *R_gene_id,
+int *R_pathway_cutpoint, int *R_ncp,
 double *R_pathway_pval, int *R_arr_rank, double *R_gene_pval){
-  
+
   int len_file_prefix = strlen(*R_file_prefix);
   char *file_prefix = new char[len_file_prefix + 1];
   file_prefix[0] = '\0';
   strcat(file_prefix, *R_file_prefix);
-  
+
   int nperm = *R_nperm;
   int nthread = *R_nthread;
   int ngene = *R_ngene;
   int ncp = *R_ncp;
-  
+
   assert(nthread == 1);
-  
+
   ivec group_id;
   load_group_id(R_group_id, group_id, ngene);
-  
+
   ivec gene_id;
   load_gene_id(R_gene_id, gene_id, ngene);
-  
+
   ivec pathway_cutpoint;
   load_pathway_cutpoint(R_pathway_cutpoint, pathway_cutpoint, ncp);
   int max_cutpoint = pathway_cutpoint[ncp - 1];
-  
+
   string fprefix (file_prefix);
   svec gene_out (ngene, fprefix);
   for(int g = 0; g < ngene; ++g){
@@ -1696,10 +1697,10 @@ double *R_pathway_pval, int *R_arr_rank, double *R_gene_pval){
     gid << gene_id[g];
     gene_out[g] = gene_out[g] + string(".CID.") + cid.str() + string(".GID.") + gid.str() + string(".bin");
   }
-  
+
   vector<VecMinp> gene_stat (ngene, VecMinp(nperm + 1, MINP0));
   imat gene_p_stat (ngene, ivec(nperm + 1, -1));
-  
+
   for(int g = 0; g < ngene; ++g){
     fstream gin(gene_out[g].c_str(), ios::in | ios::binary);
     //ivec zero_loc;
@@ -1718,13 +1719,13 @@ double *R_pathway_pval, int *R_arr_rank, double *R_gene_pval){
     }
     VecMinp().swap(gene_stat[g]);
   }
-  
+
   vector<VecMinp>().swap(gene_stat);
-  
+
   for(int g = 0; g < ngene; ++g){
     R_gene_pval[g] = (gene_p_stat[g][0] + 1.0) / (nperm + 1);
   }
-  
+
   vector<VecStat> stat(ncp, VecStat (nperm + 1, STAT0));
   for(int i = 0; i < nperm + 1; ++i){
     fvec s(ngene, .0f);
@@ -1737,16 +1738,16 @@ double *R_pathway_pval, int *R_arr_rank, double *R_gene_pval){
         s[g] += s[g - 1];
       }
     }
-    
+
     for(int k = 0; k < ncp; ++k){
       float u = -s[pathway_cutpoint[k]];
       stat[k][i].stat = u;
       stat[k][i].id = i;
     }
   }
-  
+
   imat().swap(gene_p_stat);
-  
+
   imat arr_rank(ncp, ivec (nperm + 1, 0));
   for(int k = 0; k < ncp; ++k){
     sort(stat[k].begin(), stat[k].end(), descending);
@@ -1757,7 +1758,7 @@ double *R_pathway_pval, int *R_arr_rank, double *R_gene_pval){
     VecStat().swap(stat[k]);
   }
   vector<VecStat>().swap(stat);
-  
+
   ivec pathway_min_p(nperm + 1, -1);
   ivec subsum(nthread, 0);
   ivec subtie(nthread, 0);
@@ -1769,7 +1770,7 @@ double *R_pathway_pval, int *R_arr_rank, double *R_gene_pval){
     }
   }
   pathway_min_p[0] = m;
-  
+
   for(int i = 1; i < nperm + 1; ++i){
     int tid = 0;
     int m = nperm + 1;
@@ -1787,7 +1788,7 @@ double *R_pathway_pval, int *R_arr_rank, double *R_gene_pval){
       ;
     }
   }
-  
+
   *R_pathway_pval = 1.0;
   int rep = 0;
   for(int t = 0; t < nthread; ++t){
@@ -1796,13 +1797,12 @@ double *R_pathway_pval, int *R_arr_rank, double *R_gene_pval){
   }
   *R_pathway_pval += rep / 2.0;
   *R_pathway_pval /= nperm + 1;
-  
-  
+
+
   delete[] file_prefix;
-  
-  
+
+
 }
 
 }
 #endif
-

--- a/src/artp3.cpp
+++ b/src/artp3.cpp
@@ -924,7 +924,7 @@ int *R_sel_id, int *R_marg_id){
   for(int g = 0; g < ngene; ++g){
   	int ncp = cutpoint[g].size();
   	vector<VecStat> stat(ncp, VecStat (nperm + 1, STAT0));
-    fstream gin(gene_out[g].c_str(), ios::in | ios::binary);
+    /*fstream gin(gene_out[g].c_str(), ios::in | ios::binary);
 
   	for(int i = 0; i < nperm + 1; ++i){
   		for(int j = 0; j < ncp; ++j){
@@ -934,7 +934,8 @@ int *R_sel_id, int *R_marg_id){
   			stat[j][i].id = i;
   		}
   	}
-  	gin.close();
+  	gin.close();*/
+    read_in_buffer(gene_out[g].c_str(), ncp, nperm+1, stat);
 
     if(remove(gene_out[g].c_str())){
       error("Cannot delete gene output file");

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -37,7 +37,7 @@ int segment_read(char *buff, const int len, const int count) {
 }
 
 template <class T>
-void read_in_buffer(std::string filename, int nrow, int ncol, std::vector<T>& output) {
+void read_in_buffer(std::string filename, int nrow, int ncol, std::vector<T>& output, int nthread) {
 
 	/*
 TODO: READING TO BUFFER;
@@ -74,12 +74,10 @@ Verified: testbuffer1.cpp
 #else
 	fclose(stdin);
 #endif
-	int nthreads;
 	int i;
 #pragma omp parallel
 	{
-		nthreads = omp_get_num_threads();
-#pragma omp parallel for num_threads(nthreads) private(i)  shared(output)
+#pragma omp parallel for num_threads(nthread) private(i)  shared(output)
 		for (i = 0; i < sizeA; i++) {
 			int ii = i%nrow;// Row
 			int jj = i/nrow;// Col

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -36,7 +36,7 @@ int segment_read(char *buff, const int len, const int count) {
 	return 1;
 }
 
-template <class T> 
+template <class T>
 void read_in_buffer(std::string filename, int nrow, int ncol, std::vector<T>& output) {
 
 	/*
@@ -72,7 +72,7 @@ void read_in_buffer(std::string filename, int nrow, int ncol, std::vector<T>& ou
 #endif
 #ifndef BUFFER_FREAD_ENABLE
 	fin.close();
-#else 
+#else
 	fclose(stdin);
 #endif
 	std::cout << "Read into OMP" << std::endl;
@@ -83,12 +83,15 @@ void read_in_buffer(std::string filename, int nrow, int ncol, std::vector<T>& ou
 			nthreads = omp_get_num_threads();
 //			std::cout << "Thread:" << nthreads <<std::endl;
 #pragma omp parallel for num_threads(nthreads) private(i)  shared(output)
-			for (i = 1; i < sizeA; i++) {
-				output[i] = buffer_float[i];
-				
-			}
+for (i = 0; i < sizeA; i++) {
+	int ii = i%nrow;// Row
+	int jj = i/nrow;// Col
+	output[ii][jj].stat = buffer_float[i];
+	output[ii][jj].id= jj;
+}
 		}
 	free(buffer);
+		std::cout << "Read into OMP Finished." << std::endl;
 	}
 #endif
 

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -1,7 +1,7 @@
 #ifndef BUFFER_BIN_ARTPS
 #define BUFFER_BIN_ARTPS
 
-#define PRINT_DEB
+//#define PRINT_DEB
 /*
 Task:
 Buffer reading binary file,
@@ -27,17 +27,24 @@ artp3.cpp:
 //		filename
 //		nrow/ncol
 //      output
+int segment_read(char *buff, const int len, const int count) {
+	return 1;
+}
+
 template <class T> 
-void read_in_buffer(std::string filename, int nrow, int ncol, std::vector<T> ouput){
+void read_in_buffer(std::string filename, int nrow, int ncol, std::vector<T>& output) {
+
 	/*
 	TODO: READING TO BUFFER;
 	Verified: testbuffer1.cpp
 	*/
+	std::cout << "Read into buffer" << std::endl;
 	size_t mul = sizeof(float) / sizeof(char); // mul >= 2
 	const long size_len = (long)nrow*((long)ncol)*mul; // verify size_len == size
+	size_t sizeA = nrow*ncol;
 	// buffer read, type = float
-    char * buffer = (char *)malloc(sizeof(char)*size_len);
-	if (buffer == NULL){
+	char * buffer = (char *)malloc(sizeof(char)*size_len);
+	if (buffer == NULL) {
 		std::cout << "Out of Memory." << std::endl;
 		exit(1);
 	}
@@ -45,16 +52,29 @@ void read_in_buffer(std::string filename, int nrow, int ncol, std::vector<T> oup
 	fin.read(buffer, size_len);
 	float * buffer_float = (float *)buffer;  //TODO: recasting char* to float *
 #ifdef PRINT_DEB
-	for (int i = 0; i < nrow; i++){
+	for (int i = 0; i < nrow; i++) {
 		std::cout << "\n[" << i << ",]:\t";
 		for (int j = 0; j < ncol; j++)
-			std::cout  << buffer_float[i*ncol + j]<<"\t";
+			std::cout << buffer_float[i*ncol + j] << "\t";
 	}
 	std::cout << "\n";
 #endif
 	fin.close();
+	std::cout << "Read into OMP" << std::endl;
+		int nthreads;
+		int i;
+#pragma omp parallel
+		{
+			nthreads = omp_get_num_threads();
+			std::cout << "Thread:" << nthreads <<std::endl;
+#pragma omp parallel for num_threads(nthreads) private(i)  shared(output)
+			for (i = 1; i < sizeA; i++) {
+				output[i] = buffer_float[i];
+				
+			}
+		}
 	free(buffer);
-}
+	}
 #endif
 
 /*TEST FILE LIST
@@ -71,53 +91,55 @@ void read_in_buffer(std::string filename, int nrow, int ncol, std::vector<T> oup
 #include <sys/time.h>
 #include "../ARTP3/src/buffer.h"
 class StopWatch {
-	timeval     started;
-	std::string msg;
+timeval     started;
+std::string msg;
 
 public:
-	StopWatch(const std::string& m) : msg(m)
-	{
-		gettimeofday(&started, NULL);
-	}
+StopWatch(const std::string& m) : msg(m)
+{
+gettimeofday(&started, NULL);
+}
 
-	~StopWatch() {
-		std::cerr << msg << " " << usecs() << " µsecs" << std::endl;
-	}
+~StopWatch() {
+std::cerr << msg << " " << usecs() << " µsecs" << std::endl;
+}
 
-	unsigned usecs() const {
-		timeval t2;
-		gettimeofday(&t2, NULL);
+unsigned usecs() const {
+timeval t2;
+gettimeofday(&t2, NULL);
 
-		return (t2.tv_sec - started.tv_sec) * 1000000 + (t2.tv_usec - started.tv_usec);
-	}
+return (t2.tv_sec - started.tv_sec) * 1000000 + (t2.tv_usec - started.tv_usec);
+}
 };
 using namespace std;
 
 int main()
 {
-	int nrow = 10;
-	int ncol = 2;
-	std::string filename("raw.dta");
-	{
-		StopWatch w1("Write file in");
-		ofstream f1("raw.dta", ios::binary | ios::out);
-		float f = 3.14159f;
-		if (f1.is_open()) {
-			for (int i = 0; i < nrow; i++) {
-				for (int j = 0; j < ncol; j++) {
-					float ff = f*(i + j);
-					f1.write(reinterpret_cast<const char*>(&ff), sizeof(f));
-				}
-			}
-			f1.close();
-		}
-	}
-	{// TEST read buffer
-	std:vector<float> U;
-		read_in_buffer(filename, 10, 2, U);
-
-	}
-	return 0;
+int nrow = 12345679;
+int ncol = 7;
+std::string filename("raw.dta");
+{
+StopWatch w1("Write file in");
+ofstream f1("raw.dta", ios::binary | ios::out);
+float f = 3.14159f;
+if (f1.is_open()) {
+for (int i = 0; i < nrow; i++) {
+for (int j = 0; j < ncol; j++) {
+float ff = f*(i + j);
+f1.write(reinterpret_cast<const char*>(&ff), sizeof(f));
+}
+}
+f1.close();
+}
+}
+{// TEST read buffer
+StopWatch ww2("Read file in OMP");
+std:vector<float> U;
+U.resize(nrow*ncol);
+read_in_buffer(filename, nrow, ncol, U);
+//for (int i = 0; i < nrow*ncol; i++) cout << U[i] << '\t';
+}
+return 0;
 }
 >>>>>>>>>>>>>EOF  testbuffer1.cpp >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 */

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -18,7 +18,7 @@ artp3.cpp:
 #include <iostream>
 #include <fstream>
 #include <stdio.h>
-#include <stdio.h>
+#include <stdlib.h>
 #include <omp.h>
 
 // para:
@@ -28,33 +28,22 @@ artp3.cpp:
 template <class T> 
 void read_in_buffer(std::string filename, int nrow, int ncol, std::vector<T> ouput){
 	/*
-	READING TO BUFFER;
+	TODO: READING TO BUFFER;
+	Verified: testbuffer1.cpp
 	*/
-	long size_len = (long)nrow*((long)ncol); // verify size_len == size
-	// buffer read, type = float
 	size_t mul = sizeof(float) / sizeof(unsigned char);
-	FILE *fp;
-	fp = fopen(filename.c_str(), "rb");// open as binary
-	fseek(fp, 0, SEEK_END);
-	long size = ftell(fp);         /*calc the size needed*/
-	fseek(fp, 0, SEEK_SET);
-	unsigned char * buffer = (unsigned *)malloc(size); /*allocalte space on heap*/
-	float * buffer_float = (float *)buffer;// recasting to float
-	if (fp == NULL){ /*ERROR detection if file == empty*/
-		printf("Error: There was an Error reading the file %s \n", path);
-		exit(1);
+	const long size_len = (long)nrow*((long)ncol)*mul; // verify size_len == size
+	// buffer read, type = float
+    char * buffer = (char *)malloc(sizeof(char)*size_len);
+	std::ifstream fin(filename.c_str(), std::ios::in | std::ios::binary);
+	fin.read(buffer, size_len);
+	float * buffer_float = (float *)buffer;
+	for (int i = 0; i < nrow; i++){
+		std::cout << "\n[" << i << ",]:\t";
+		for (int j = 0; j < ncol; j++)
+			std::cout  << buffer_float[i*ncol + j]<<"\t";
 	}
-	else if (fread(&buffer, sizeof(*buffer), size, fp) != size){ /* if count of read bytes != calculated size of .bin file -> ERROR*/
-		printf("Error: There was an Error reading the file %s - %d\n", path, r);
-		exit(1);
-	}
-	else{
-		int i;
-		for (i = 0; i<size/mul; i++){
-			std::cout << buffer_float[i];
-		}
-	}
-	free(buffer);
-	fclose(fp);
+	std::cout << "\n";
+
 }
 #endif

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -1,0 +1,17 @@
+#ifndef BUFFER_BIN_ARTPS
+#define BUFFER_BIN_ARTPS
+/*
+Task:
+Buffer reading binary file,
+given file size (nrow ncol)
+all data are float
+
+.815
+artp3.cpp:
+- artp3_chr    L672-683
+- adajoint_chr L924-936
+- artp3        L1059-1069
+
+*/
+
+#endif

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -44,7 +44,6 @@ TODO: READING TO BUFFER;
 Verified: testbuffer1.cpp
 */
 	std::ios::sync_with_stdio(false);
-	std::cout << "Read into buffer" << std::endl;
 	size_t mul = sizeof(float) / sizeof(char); // mul >= 2
 	const long size_len = (long)nrow*((long)ncol)*mul; // verify size_len == size
 	size_t sizeA = nrow*ncol;

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -31,19 +31,85 @@ void read_in_buffer(std::string filename, int nrow, int ncol, std::vector<T> oup
 	TODO: READING TO BUFFER;
 	Verified: testbuffer1.cpp
 	*/
-	size_t mul = sizeof(float) / sizeof(unsigned char);
+	size_t mul = sizeof(float) / sizeof(char); // mul >= 2
 	const long size_len = (long)nrow*((long)ncol)*mul; // verify size_len == size
 	// buffer read, type = float
     char * buffer = (char *)malloc(sizeof(char)*size_len);
 	std::ifstream fin(filename.c_str(), std::ios::in | std::ios::binary);
 	fin.read(buffer, size_len);
-	float * buffer_float = (float *)buffer;
+	float * buffer_float = (float *)buffer;  //TODO: recasting char* to float *
 	for (int i = 0; i < nrow; i++){
 		std::cout << "\n[" << i << ",]:\t";
 		for (int j = 0; j < ncol; j++)
 			std::cout  << buffer_float[i*ncol + j]<<"\t";
 	}
 	std::cout << "\n";
-
+	fin.close();
+	free(buffer);
 }
 #endif
+
+/*TEST FILE LIST
+>>>>>>>>>>>>>  testbuffer1.cpp >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <stdio.h>
+#include <omp.h>
+#include <vector>
+
+#include <time.h>
+
+#include <sys/time.h>
+#include "../ARTP3/src/buffer.h"
+class StopWatch {
+	timeval     started;
+	std::string msg;
+
+public:
+	StopWatch(const std::string& m) : msg(m)
+	{
+		gettimeofday(&started, NULL);
+	}
+
+	~StopWatch() {
+		std::cerr << msg << " " << usecs() << " µsecs" << std::endl;
+	}
+
+	unsigned usecs() const {
+		timeval t2;
+		gettimeofday(&t2, NULL);
+
+		return (t2.tv_sec - started.tv_sec) * 1000000 + (t2.tv_usec - started.tv_usec);
+	}
+};
+using namespace std;
+
+int main()
+{
+	int nrow = 10;
+	int ncol = 2;
+	std::string filename("raw.dta");
+	{
+		StopWatch w1("Write file in");
+		ofstream f1("raw.dta", ios::binary | ios::out);
+		float f = 3.14159f;
+		if (f1.is_open()) {
+			for (int i = 0; i < nrow; i++) {
+				for (int j = 0; j < ncol; j++) {
+					float ff = f*(i + j);
+					f1.write(reinterpret_cast<const char*>(&ff), sizeof(f));
+				}
+			}
+			f1.close();
+		}
+	}
+	{// TEST read buffer
+	std:vector<float> U;
+		read_in_buffer(filename, 10, 2, U);
+
+	}
+	return 0;
+}
+>>>>>>>>>>>>>EOF  testbuffer1.cpp >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+*/

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -11,9 +11,9 @@ all data are float
 
 .815
 artp3.cpp:
-- artp3_chr    L672-683
-- adajoint_chr L924-936
-- artp3        L1059-1069
+- artp3_chr    L672-683      [x]
+- adajoint_chr L924-936      [x]
+- artp3        L1059-1069    [skip]
 
 */
 
@@ -40,9 +40,9 @@ template <class T>
 void read_in_buffer(std::string filename, int nrow, int ncol, std::vector<T>& output) {
 
 	/*
-	TODO: READING TO BUFFER;
-	Verified: testbuffer1.cpp
-	*/
+TODO: READING TO BUFFER;
+Verified: testbuffer1.cpp
+*/
 	std::ios::sync_with_stdio(false);
 	std::cout << "Read into buffer" << std::endl;
 	size_t mul = sizeof(float) / sizeof(char); // mul >= 2
@@ -58,7 +58,7 @@ void read_in_buffer(std::string filename, int nrow, int ncol, std::vector<T>& ou
 	std::ifstream fin(filename.c_str(), std::ios::in | std::ios::binary);
 	fin.read(buffer, size_len);
 #else
-    freopen(filename.c_str(),"rb", stdin);
+	freopen(filename.c_str(),"rb", stdin);
 	fread(buffer,1,size_len, stdin);
 #endif
 	float * buffer_float = (float *)buffer;  //TODO: recasting char* to float *
@@ -75,89 +75,19 @@ void read_in_buffer(std::string filename, int nrow, int ncol, std::vector<T>& ou
 #else
 	fclose(stdin);
 #endif
-	std::cout << "Read into OMP" << std::endl;
-		int nthreads;
-		int i;
+	int nthreads;
+	int i;
 #pragma omp parallel
-		{
-			nthreads = omp_get_num_threads();
-//			std::cout << "Thread:" << nthreads <<std::endl;
+	{
+		nthreads = omp_get_num_threads();
 #pragma omp parallel for num_threads(nthreads) private(i)  shared(output)
-for (i = 0; i < sizeA; i++) {
-	int ii = i%nrow;// Row
-	int jj = i/nrow;// Col
-	output[ii][jj].stat = buffer_float[i];
-	output[ii][jj].id= jj;
-}
+		for (i = 0; i < sizeA; i++) {
+			int ii = i%nrow;// Row
+			int jj = i/nrow;// Col
+			output[ii][jj].stat = buffer_float[i];
+			output[ii][jj].id= jj;
 		}
-	free(buffer);
-		std::cout << "Read into OMP Finished." << std::endl;
 	}
+	free(buffer);
+}
 #endif
-
-/*TEST FILE LIST
->>>>>>>>>>>>>  testbuffer1.cpp >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-#include <iostream>
-#include <fstream>
-#include <string>
-#include <stdio.h>
-#include <omp.h>
-#include <vector>
-
-#include <time.h>
-
-#include <sys/time.h>
-#include "../ARTP3/src/buffer.h"
-class StopWatch {
-timeval     started;
-std::string msg;
-
-public:
-StopWatch(const std::string& m) : msg(m)
-{
-gettimeofday(&started, NULL);
-}
-
-~StopWatch() {
-std::cerr << msg << " " << usecs() << " µsecs" << std::endl;
-}
-
-unsigned usecs() const {
-timeval t2;
-gettimeofday(&t2, NULL);
-
-return (t2.tv_sec - started.tv_sec) * 1000000 + (t2.tv_usec - started.tv_usec);
-}
-};
-using namespace std;
-
-int main()
-{
-int nrow = 12345679;
-int ncol = 7;
-std::string filename("raw.dta");
-{
-StopWatch w1("Write file in");
-ofstream f1("raw.dta", ios::binary | ios::out);
-float f = 3.14159f;
-if (f1.is_open()) {
-for (int i = 0; i < nrow; i++) {
-for (int j = 0; j < ncol; j++) {
-float ff = f*(i + j);
-f1.write(reinterpret_cast<const char*>(&ff), sizeof(f));
-}
-}
-f1.close();
-}
-}
-{// TEST read buffer
-StopWatch ww2("Read file in OMP");
-std:vector<float> U;
-U.resize(nrow*ncol);
-read_in_buffer(filename, nrow, ncol, U);
-//for (int i = 0; i < nrow*ncol; i++) cout << U[i] << '\t';
-}
-return 0;
-}
->>>>>>>>>>>>>EOF  testbuffer1.cpp >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-*/

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -1,5 +1,7 @@
 #ifndef BUFFER_BIN_ARTPS
 #define BUFFER_BIN_ARTPS
+
+#define PRINT_DEB
 /*
 Task:
 Buffer reading binary file,
@@ -35,15 +37,21 @@ void read_in_buffer(std::string filename, int nrow, int ncol, std::vector<T> oup
 	const long size_len = (long)nrow*((long)ncol)*mul; // verify size_len == size
 	// buffer read, type = float
     char * buffer = (char *)malloc(sizeof(char)*size_len);
+	if (buffer == NULL){
+		std::cout << "Out of Memory." << std::endl;
+		exit(1);
+	}
 	std::ifstream fin(filename.c_str(), std::ios::in | std::ios::binary);
 	fin.read(buffer, size_len);
 	float * buffer_float = (float *)buffer;  //TODO: recasting char* to float *
+#ifdef PRINT_DEB
 	for (int i = 0; i < nrow; i++){
 		std::cout << "\n[" << i << ",]:\t";
 		for (int j = 0; j < ncol; j++)
 			std::cout  << buffer_float[i*ncol + j]<<"\t";
 	}
 	std::cout << "\n";
+#endif
 	fin.close();
 	free(buffer);
 }

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -38,6 +38,7 @@ void read_in_buffer(std::string filename, int nrow, int ncol, std::vector<T>& ou
 	TODO: READING TO BUFFER;
 	Verified: testbuffer1.cpp
 	*/
+	std::ios::sync_with_stdio(false);
 	std::cout << "Read into buffer" << std::endl;
 	size_t mul = sizeof(float) / sizeof(char); // mul >= 2
 	const long size_len = (long)nrow*((long)ncol)*mul; // verify size_len == size
@@ -101,7 +102,7 @@ gettimeofday(&started, NULL);
 }
 
 ~StopWatch() {
-std::cerr << msg << " " << usecs() << " µsecs" << std::endl;
+std::cerr << msg << " " << usecs() << " Âµsecs" << std::endl;
 }
 
 unsigned usecs() const {

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -14,4 +14,47 @@ artp3.cpp:
 
 */
 
+#include <string>
+#include <iostream>
+#include <fstream>
+#include <stdio.h>
+#include <stdio.h>
+#include <omp.h>
+
+// para:
+//		filename
+//		nrow/ncol
+//      output
+template <class T> 
+void read_in_buffer(std::string filename, int nrow, int ncol, std::vector<T> ouput){
+	/*
+	READING TO BUFFER;
+	*/
+	long size_len = (long)nrow*((long)ncol); // verify size_len == size
+	// buffer read, type = float
+	size_t mul = sizeof(float) / sizeof(unsigned char);
+	FILE *fp;
+	fp = fopen(filename.c_str(), "rb");// open as binary
+	fseek(fp, 0, SEEK_END);
+	long size = ftell(fp);         /*calc the size needed*/
+	fseek(fp, 0, SEEK_SET);
+	unsigned char * buffer = (unsigned *)malloc(size); /*allocalte space on heap*/
+	float * buffer_float = (float *)buffer;// recasting to float
+	if (fp == NULL){ /*ERROR detection if file == empty*/
+		printf("Error: There was an Error reading the file %s \n", path);
+		exit(1);
+	}
+	else if (fread(&buffer, sizeof(*buffer), size, fp) != size){ /* if count of read bytes != calculated size of .bin file -> ERROR*/
+		printf("Error: There was an Error reading the file %s - %d\n", path, r);
+		exit(1);
+	}
+	else{
+		int i;
+		for (i = 0; i<size/mul; i++){
+			std::cout << buffer_float[i];
+		}
+	}
+	free(buffer);
+	fclose(fp);
+}
 #endif


### PR DESCRIPTION
# Main
- Results are identical.
- Buffer read is useful when the temp file is extremely large.
- With/without buffer methods failed on Revolution R Open 3.2.2 when nperm is large. Core dump shows evidence of Rlapack problem and can't alloc memory, which has nothing to do with the package itself.
- Buffer/without buffer read method varies
# Simulation

Read file(not the simulation itself) comparison:

| Method | Time(s) |
| :-- | :-- |
| cin | ~6 |
| cin(sync_with_stdio(false)) | ~2 |
| fread | ~.2 |
# Hints

The inner loop in buffer.h could be modified as it compute row/column index every time. I am thinking HOWTO.
